### PR TITLE
исправить BEMHTML.apply(undefined)

### DIFF
--- a/lib/bemhtml/api.js
+++ b/lib/bemhtml/api.js
@@ -41,17 +41,21 @@ api.translate = function translate(source, options) {
 
   var exportName = options.exportName,
       xjst_apply = options.async ?
-          'return xjst.applyAsync.call(' + (options.raw ? 'this' : '[this]') + ', options.callback);\n' :
-          'return xjst.apply.call(' + (options.raw ? 'this' : '[this]') + ');\n';
+          'return xjst.applyAsync.call(' + (options.raw ? 'context' : '[context]') + ', options.callback);\n' :
+          'return xjst.apply.call(' + (options.raw ? 'context' : '[context]') + ');\n';
 
   return 'var ' + exportName + ' = function() {\n' +
          '  var cache,\n' +
          '      xjst = '  + xjstJS + ';\n' +
          '  return function(options) {\n' +
+         '    var context = this;\n' +
          '    if (!options) options = {};\n' +
          '    cache = options.cache;\n' +
+         '    return function() {\n' +
+         '      if (context === this) context = undefined;\n' +
          (vars.length > 0 ? '    var ' + vars.join(', ') + ';\n' : '') +
-         '    ' + xjst_apply +
+         '      ' + xjst_apply +
+         '    }.call(null);\n' +
          '  };\n' +
          '}();\n' +
          'typeof exports === "undefined" || (exports.' + exportName + ' = ' + exportName + ');';


### PR DESCRIPTION
(Порт соответствующего фикса из bem-bl)

Так как `BEMHTML.apply` по сути есть `Function.prototype.apply`,
передача `undefined` в качестве аргумента сделает контекст равным
`global` (или `window` в браузере). Это приводит к некорректной работе
шаблонов, и "зависанию" в Firefox.

Правильным решением является обработка этого случая и замена контекста
на undefined, в случае его равенства с `global`.
