### PR TITLE
Added `asyncify` option to bemhtml tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ bemhtml
 * *String* **exportName** — Имя переменной-обработчика BEMHTML. По умолчанию — `'BEMHTML'`.
 * *Boolean* **devMode** — Development-режим. По умолчанию — `true`.
 * *Boolean* **cache** — Кеширование. По умолчанию — `true`.
+* *Boolean* **asyncify** — Передаётся библиотеке xjst, задаёт режим компиляции. По умолчанию — `false`.
 
 **Пример**
 

--- a/lib/bemhtml/api.js
+++ b/lib/bemhtml/api.js
@@ -34,7 +34,10 @@ api.translate = function translate(source, options) {
     var xjstJS = options.devMode ?
                    xjst.compile(xjstTree, '', { 'no-opt': true })
                    :
-                   xjst.compile(xjstTree, { engine: 'sort-group' });
+                   xjst.compile(xjstTree, {
+                     engine: 'sort-group',
+                     asyncify: options.asyncify
+                   });
   } catch (e) {
     throw new Error("xjst to js compilation failed:\n" + e.stack);
   }

--- a/techs/bemhtml.js
+++ b/techs/bemhtml.js
@@ -13,6 +13,7 @@
  * * *String* **exportName** — Имя переменной-обработчика BEMHTML. По умолчанию — `'BEMHTML'`.
  * * *Boolean* **devMode** — Development-режим. По умолчанию — `true`.
  * * *Boolean* **cache** — Кеширование. По умолчанию — `true`.
+ * * *Boolean* **asyncify** — Передаётся библиотеке xjst, задаёт режим компиляции. По умолчанию — `false`.
  *
  * **Пример**
  *
@@ -30,6 +31,7 @@ module.exports = require('enb/lib/build-flow').create()
     .defineOption('exportName', 'BEMHTML')
     .defineOption('devMode', true)
     .defineOption('cache', true)
+    .defineOption('asyncify', false)
     .useFileList('bemhtml')
     .builder(function(sourceFiles) {
         var _this = this;
@@ -51,6 +53,7 @@ module.exports = require('enb/lib/build-flow').create()
                 devMode: this._devMode,
                 cache: this._cache,
                 exportName: this._exportName,
+                asyncify: this._asyncify,
                 async: false
             };
         }


### PR DESCRIPTION
При рендеринге тяжёлых шаблонов на клиенте иногда возникает ошибка "Too much recursion". Баг специфичен для firefox под windows, при этом воспроизводится не всегда.

Проблема решена в библиотеке xjst в версии 0.5.x. Для версии 0.4.x нужно добавлять параметр `asyncify: true`.

После исправления https://github.com/enb-make/enb-bemhtml/issues/13 коммит можно будет откатить.
