### PR TITLE
fix for combined BEMHTML and BEMTREE techs usage

### DIFF
--- a/lib/bemhtml/api.js
+++ b/lib/bemhtml/api.js
@@ -46,6 +46,7 @@ api.translate = function translate(source, options) {
 
   return 'var ' + exportName + ' = function() {\n' +
          '  var cache,\n' +
+         '      exports = {},\n' +
          '      xjst = '  + xjstJS + ';\n' +
          '  return function(options) {\n' +
          '    var context = this;\n' +


### PR DESCRIPTION
Иногда возникает ситуация, когда нужно из BEMTREE-шаблона позвать `BEMHTML.apply()`.
Если скомпилировать шаблоны BEMHTML и BEMTREE, а затем смержить в один файл, то шаблонизатор будет работать некорректно. Это происходит из-за неправильной работы с переменной `exports` при создании функции xjst.
Данный пул-реквест решает эту проблему.
