### PR TITLE
bemhtml: move most used vars to the scope

### DIFF
--- a/lib/bemhtml/api.js
+++ b/lib/bemhtml/api.js
@@ -1,10 +1,25 @@
 var ometajs = require('ometajs');
+var esprima = require('esprima');
+var escodegen = require('escodegen');
+var estraverse = require('estraverse');
 var xjst = require('xjst');
 var vm = require('vm');
 var bemhtml = require('../ometa/bemhtml');
 var BEMHTMLParser = bemhtml.BEMHTMLParser;
 var BEMHTMLToXJST = bemhtml.BEMHTMLToXJST;
 var BEMHTMLLogLocal = bemhtml.BEMHTMLLogLocal;
+
+var properties = {
+  _mode: '$$mode',
+  block: '$$block',
+  elem: '$$elem',
+  elemMods: '$$elemMods',
+  mods: '$$mods'
+};
+var propKeys = Object.keys(properties);
+var propValues = propKeys.map(function fetchValues(key) {
+  return properties[key];
+});
 
 var api = exports;
 
@@ -39,12 +54,16 @@ api.translate = function translate(source, options) {
     throw new Error('xjst to js compilation failed:\n' + e.stack);
   }
 
+  // Replace known context lookups with context vars
+  xjstJS = replaceContext(xjstJS);
+
   var exportName = options.exportName;
   var xjst_apply = options.async ?
           'return xjst.applyAsync.call(' + (options.raw ? 'context' : '[context]') + ', options.callback);\n' :
           'return xjst.apply.call(' + (options.raw ? 'context' : '[context]') + ');\n';
 
   return 'var ' + exportName + ' = function() {\n' +
+         '  var ' + propValues.join(', ') + ';\n' +
          '  var cache,\n' +
          '      exports = {},\n' +
          '      xjst = '  + xjstJS + ';\n' +
@@ -53,7 +72,14 @@ api.translate = function translate(source, options) {
          '    if (!options) options = {};\n' +
          '    cache = options.cache;\n' +
          '    return function() {\n' +
-         '      if (context === this) context = undefined;\n' +
+         '      if (context === this) {\n' +
+         '        context = undefined;\n' +
+         '      } else {\n' +
+                  propKeys.map(function fetchAssignments(prop) {
+                    return properties[prop] + ' = context.' + prop +
+                        ' || \'\';\n';
+                  }).join('') +
+         '      }\n' +
          (vars.length > 0 ? '    var ' + vars.join(', ') + ';\n' : '') +
          '      ' + xjst_apply +
          '    }.call(null);\n' +
@@ -79,3 +105,62 @@ api.compile = function compile(source, options) {
 
   return context.BEMHTML;
 };
+
+function replaceContext(src) {
+  function translateProp(prop) {
+    if (properties.hasOwnProperty(prop)) {
+      return properties[prop];
+    } else {
+      return false;
+    }
+  };
+
+  var applyc = null;
+  var map = null;
+
+  var ast = esprima.parse(src);
+  ast = estraverse.replace(ast, {
+    enter: function enter(node) {
+      var isFunction = node.type === 'FunctionDeclaration' ||
+                       node.type === 'FunctionExpression';
+      var id = node.id && node.id.name;
+      if (applyc === null &&
+          isFunction &&
+          (map !== null || /^(applyc|\$\d+)$/.test(id))) {
+        applyc = node;
+      } else if (applyc === null &&
+                 node.type === 'VariableDeclarator' &&
+                 /^__h\d+$/.test(id)) {
+        map = node;
+      } else if (applyc === null) {
+        return;
+      }
+
+      if (applyc !== node && isFunction) {
+        this.skip();
+        return;
+      }
+
+      if (node.type === 'MemberExpression' &&
+          node.computed === false &&
+          node.object.type === 'Identifier' &&
+          node.object.name === '__$ctx') {
+        var prop = translateProp(node.property.name || node.property.value);
+        if (!prop) {
+          return;
+        }
+
+        return { type: 'Identifier', name: prop };
+      }
+    },
+    leave: function leave(node) {
+      if (node === applyc) {
+        applyc = null;
+      }
+      if (node === map) {
+        applyc = null;
+      }
+    }
+  });
+  return escodegen.generate(ast);
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "devDependencies" : {
         "enb": ">= 0.8.22",
         "enb-validate-code": "0.0.1",
+        "estraverse": "1.5.0",
+        "esprima": "1.0.4",
+        "escodegen": "1.2.0",
         "mocha": "1.14.0",
         "chai": "1.8.1",
         "jshint": "2.3.0",

--- a/test/fixtures/bemhtml/blocks/i-bem/__html/i-bem__html.bemhtml
+++ b/test/fixtures/bemhtml/blocks/i-bem/__html/i-bem__html.bemhtml
@@ -191,14 +191,9 @@ function BEMContext(context, apply_) {
 
   // Stub out fields that will be used later
   this._start = true;
-  this._mode = '';
   this._listLength = 0;
   this._notNewList = false;
   this.position = 0;
-  this.block = undefined;
-  this.elem = undefined;
-  this.mods = undefined;
-  this.elemMods = undefined;
 };
 
 BEMContext.prototype.isArray = function isArray(obj) {
@@ -323,8 +318,7 @@ this._mode === '' {
 }
 
 default: {
-    var _this = this,
-        BEM_ = _this.BEM,
+    var BEM_ = this.BEM,
         v = this.ctx,
         buf = this._buf,
         tag;
@@ -376,14 +370,14 @@ default: {
                         if (!mixItem) continue;
 
                         var hasItem = mixItem.block || mixItem.elem,
-                            block = mixItem.block || mixItem._block || _this.block,
-                            elem = mixItem.elem || mixItem._elem || _this.elem;
+                            block = mixItem.block || mixItem._block || this.block,
+                            elem = mixItem.elem || mixItem._elem || this.elem;
 
                         hasItem && buf.push(' ');
                         BEM_.INTERNAL[hasItem? 'buildClasses' : 'buildModsClasses'](
                             block,
                             mixItem.elem || mixItem._elem ||
-                                (mixItem.block ? undefined : _this.elem),
+                                (mixItem.block ? undefined : this.elem),
                             mixItem.elemMods || mixItem.mods,
                             buf);
 

--- a/test/fixtures/bemtree/blocks/i-bem/i-bem.bemtree.xjst
+++ b/test/fixtures/bemtree/blocks/i-bem/i-bem.bemtree.xjst
@@ -19,11 +19,6 @@ function BEMContext(context, apply_) {
 
     // Stub out fields that will be used later
     this._start = true;
-    this._mode = '';
-    this.block = undefined;
-    this.elem = undefined;
-    this.mods = undefined;
-    this.elemMods = undefined;
 };
 
 BEMContext.prototype.isArray = function isArray(obj) {


### PR DESCRIPTION
Backport (or forward-port?) of:

https://github.com/bem/bem-bl/commit/b7c74fdd1d9c87f4c84f22425ef926b7989c5b0d

NOTE: Should probably go into minor or major release, not in a patch version. As it will certainly break projects that are using current `i-bem`.
